### PR TITLE
Implement HTTPS middleware.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,11 @@
 0.1.0 (In Development)
 ======================
 
-0.1.0a3 (In Development)
+0.1.0b1 (In Development)
 ------------------------
 
+- New ``https_middleware`` to allow use proper scheme in ``request.url``, when
+  deploying aiohttp behind reverse proxy with enabled HTTPS
 - Allow passing dict of URLs with list methods to flex process of matching
   request ignored to wrapping into timeout context manager
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,11 @@ lint:
 	TOXENV=lint $(MAKE) test
 
 setup-pyenv:
+ifneq ($(CIRCLECI),)
 	pyenv local 3.5.3 3.6.2
+else
+	pyenv local 3.5.4 3.6.3
+endif
 
 test: .install clean
 	$(TOX) $(tox_args) $(TOX_ARGS) -- $(TEST_ARGS)

--- a/aiohttp_middlewares/__init__.py
+++ b/aiohttp_middlewares/__init__.py
@@ -7,11 +7,13 @@ Collection of useful middlewares for aiohttp applications.
 
 """
 
-__version__ = '0.1.0a3'
+__version__ = '0.1.0b1'
 
+from .https import https_middleware
 from .timeout import timeout_middleware
 
 # Make flake8 happy
 (
+    https_middleware,
     timeout_middleware,
 )

--- a/aiohttp_middlewares/https.py
+++ b/aiohttp_middlewares/https.py
@@ -1,0 +1,82 @@
+"""
+=============
+aiohttp.https
+=============
+
+Change scheme for current request when aiohttp application deployed behind
+reverse proxy with HTTPS enabled.
+
+Usage
+=====
+
+::
+
+    from aiohttp import web
+    from aiohttp_middlewares import https_middleware
+
+    # Basic usage
+    app = web.Application(middlewares=[https_middleware()])
+
+    # Specify custom headers to match, not `X-Forwarded-Proto: https`
+    app = web.Application(
+        middlewares=https_middleware({'Forwared': 'https'}))
+
+"""
+
+import logging
+
+from aiohttp import web
+
+from .types import Handler, Middleware, StrDict
+from .utils import get_aiohttp_version
+
+
+DEFAULT_MATCH_HEADERS = {'X-Forwarded-Proto': 'https'}
+
+logger = logging.getLogger(__name__)
+
+
+def https_middleware(match_headers: StrDict=None) -> Middleware:
+    """
+    Change scheme for current request when aiohttp application deployed behind
+    reverse proxy with HTTPS enabled.
+
+    This middleware is required to use, when your aiohttp app deployed behind
+    nginx with HTTPS enabled, after aiohttp discounted
+    ``secure_proxy_ssl_header`` keyword argument in
+    https://github.com/aio-libs/aiohttp/pull/2299.
+    """
+    async def factory(app: web.Application, handler: Handler) -> Handler:
+        """Actual HTTPS middleware factory."""
+        async def middleware(request: web.Request) -> web.Response:
+            """Change scheme of current request when HTTPS headers matched."""
+            headers = DEFAULT_MATCH_HEADERS
+            if match_headers is not None:
+                headers = match_headers
+
+            if get_aiohttp_version() < (2, 3):
+                if len(headers) > 1:  # pragma: no cover
+                    logger.warning(
+                        'aiohttp <= 2.2 does not support multiple headers '
+                        'for _secure_proxy_ssl_header attr',
+                        extra={'headers': 'headers'})
+                if headers:
+                    request._secure_proxy_ssl_header = (
+                        tuple(headers.items())[0])
+            else:
+                matched = any(
+                    request.headers.get(key) == value
+                    for key, value in headers.items())
+
+                if matched:
+                    logger.debug(
+                        'Substitute request URL scheme to https',
+                        extra={
+                            'headers': headers,
+                            'request_headers': dict(request.headers),
+                        })
+                    request = request.clone(scheme='https')
+
+            return await handler(request)
+        return middleware
+    return factory

--- a/aiohttp_middlewares/types.py
+++ b/aiohttp_middlewares/types.py
@@ -13,6 +13,7 @@ from aiohttp import web
 
 
 StrCollection = Union[List[str], Set[str], Tuple[str, ...]]
+StrDict = Dict[str, str]
 Urls = Union[StrCollection, Dict[str, Union[StrCollection, str]]]
 
 Handler = Callable[[web.Request], web.Response]

--- a/aiohttp_middlewares/utils.py
+++ b/aiohttp_middlewares/utils.py
@@ -1,4 +1,14 @@
+from typing import Tuple
+
+import aiohttp
+
 from .types import Urls
+
+
+def get_aiohttp_version() -> Tuple[int, int]:
+    """Return tuple of current aiohttp MAJOR.MINOR version."""
+    return tuple(  # type: ignore
+        int(item) for item in aiohttp.__version__.split('.')[:2])
 
 
 def match_request(urls: Urls, method: str, path: str) -> bool:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coveralls==1.2.0
-Sphinx==1.6.3
+Sphinx==1.6.4
 sphinx-autodoc-typehints==1.2.3
-tox==2.8.2
+tox==2.9.1
 tox-pyenv==1.1.0
 twine==1.9.1
 wheel==0.30.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'aiohttp>=2.0,<3.0',
-        'async-timeout>=1.2,<2.0',
+        'async-timeout>=1.2,<3.0',
     ],
     platforms='any',
     classifiers=[

--- a/tests/test_https_middleware.py
+++ b/tests/test_https_middleware.py
@@ -1,0 +1,55 @@
+import pytest
+
+from aiohttp import web
+
+from aiohttp_middlewares import https_middleware
+from aiohttp_middlewares.utils import get_aiohttp_version
+
+
+def create_app(match_headers):
+    app = web.Application(middlewares=[https_middleware(match_headers)])
+    app.router.add_route('GET', '/', handler)
+    return app
+
+
+async def handler(request):
+    return web.json_response(request.url.scheme)
+
+
+@pytest.mark.parametrize('match_headers, request_headers, expected', [
+    (None, None, 'http'),
+    (None, {'X-Forwarded-Proto': 'http'}, 'http'),
+    (None, {'X-Forwarded-Proto': 'https'}, 'https'),
+    ({}, None, 'http'),
+    ({}, {'X-Forwarded-Proto': 'http'}, 'http'),
+    ({'Forwarded': 'https'}, None, 'http'),
+    ({'Forwarded': 'https'}, {'X-Forwarded-Proto': 'http'}, 'http'),
+    ({'Forwarded': 'https'}, {'X-Forwarded-Proto': 'https'}, 'http'),
+    ({'Forwarded': 'https'}, {'Forwarded': 'http'}, 'http'),
+    ({'Forwarded': 'https'}, {'Forwarded': 'https'}, 'https'),
+])
+async def test_https_middleware(test_client,
+                                match_headers,
+                                request_headers,
+                                expected):
+    client = await test_client(create_app(match_headers))
+    response = await client.get('/', headers=request_headers)
+    assert await response.json() == expected
+
+
+@pytest.mark.skipif(
+    get_aiohttp_version() != (2, 0) and get_aiohttp_version() < (2, 3),
+    reason='aiohttp 2.0 & 2.3+')
+async def test_https_middleware_aiohttp20_23_empty_match_headers(test_client):
+    client = await test_client(create_app({}))
+    response = await client.get('/', headers={'X-Forwarded-Proto': 'https'})
+    assert await response.json() == 'http'
+
+
+@pytest.mark.skipif(
+    get_aiohttp_version() not in ((2, 1), (2, 2)),
+    reason='aiohttp 2.1 & 2.2')
+async def test_https_middleware_aiohttp21_22_empty_match_headers(test_client):
+    client = await test_client(create_app({}))
+    response = await client.get('/', headers={'X-Forwarded-Proto': 'https'})
+    assert await response.json() == 'https'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
+import aiohttp
 import pytest
 
-from aiohttp_middlewares.utils import match_request
+from aiohttp_middlewares.utils import get_aiohttp_version, match_request
 
 
 URLS_COLLECTION = {'/slow-url', '/very-slow-url'}
@@ -8,6 +9,20 @@ URLS_DICT = {
     '/slow-url': 'POST',
     '/very-slow-url': ['get', 'post'],
 }
+
+
+@pytest.mark.parametrize('version, expected', [
+    ('2.0.7', (2, 0)),
+    ('2.1.0', (2, 1)),
+    ('2.2.5', (2, 2)),
+    ('2.3.0a4', (2, 3)),
+    ('2.3.0', (2, 3)),
+    ('2.3.1a1', (2, 3)),
+    ('2.3.1', (2, 3)),
+])
+def test_get_aiohttp_version(monkeypatch, version, expected):
+    monkeypatch.setattr(aiohttp, '__version__', version)
+    assert get_aiohttp_version() == expected
 
 
 @pytest.mark.parametrize('urls, request_method, request_path, expected', [

--- a/tox.ini
+++ b/tox.ini
@@ -4,28 +4,30 @@ import-order-style = smarkets
 max-complexity = 15
 
 [tox]
-envlist = lint,py35,py36
+envlist = lint,py35-aiohttp{20,21,22,23},py36-aiohttp{20,21,22,23}
 
 [testenv]
+whitelist_externals = rm
 deps =
-    aiohttp==2.2.5
-    chardet==3.0.4
+    aiohttp20: aiohttp==2.0.7
+    aiohttp21: aiohttp==2.1.0
+    aiohttp22: aiohttp==2.2.5
+    aiohttp23: aiohttp==2.3.1
+    aiohttp23: async_timeout==2.0.0
     coverage==4.4.1
     fastjsonschema==1.1
     jsl==0.2.4
     jsonschema==2.6.0
-    multidict==3.2.0
-    pytest==3.2.2
+    pytest==3.2.3
     pytest-aiohttp==0.1.3
     pytest-cov==2.5.1
-    yarl==0.12.0
 passenv =
     PYTHONPATH
 setenv =
     PYTHONPATH=.
     USER=playpauseandstop
 commands =
-    pytest --cov=aiohttp_middlewares --no-cov-on-fail --cov-fail-under=95 --cov-branch {posargs} tests/
+    pytest --cov=aiohttp_middlewares --cov-append --no-cov-on-fail --cov-fail-under=85 --cov-branch {posargs} tests/
 
 [testenv:lint]
 skip_install = True
@@ -40,7 +42,7 @@ deps =
     flake8-string-format==0.2.3
     flake8-tidy-imports==1.1.0
     mccabe==0.6.1
-    mypy==0.521
+    mypy==0.540
     pep8-naming==0.4.1
     pycodestyle==2.3.1
     pyflakes==1.6.0


### PR DESCRIPTION
HTTPS middleware is required after aiohttp discounted ``secure_proxy_ssl_header``
keyword argument at making handler.