### PR TITLE
Implement shield middleware.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,10 @@
 0.1.0b2 (In Development)
 ------------------------
 
-- Allow to match URL by regexp for timeout middleware (this is hidden feature
-  for now).
+- New ``shield_middleware`` to wrap request handler into
+  `asyncio.shield <https://docs.python.org/3/library/asyncio-task.html#asyncio.shield>`_
+  helper before execution
+- Allow to match URL by regexp for shield/timeout middleware
 
 0.1.0b1 (2017-10-20)
 --------------------

--- a/aiohttp_middlewares/__init__.py
+++ b/aiohttp_middlewares/__init__.py
@@ -9,11 +9,16 @@ Collection of useful middlewares for aiohttp applications.
 
 __version__ = '0.1.0b2'
 
+from .constants import IDEMPOTENT_METHODS, NON_IDEMPOTENT_METHODS
 from .https import https_middleware
+from .shield import shield_middleware
 from .timeout import timeout_middleware
 
 # Make flake8 happy
 (
     https_middleware,
+    IDEMPOTENT_METHODS,
+    NON_IDEMPOTENT_METHODS,
+    shield_middleware,
     timeout_middleware,
 )

--- a/aiohttp_middlewares/constants.py
+++ b/aiohttp_middlewares/constants.py
@@ -1,0 +1,14 @@
+"""
+=============================
+aiohttp_middlewares.constants
+=============================
+
+Collection of constants for ``aiohttp_middlewares`` project.
+
+"""
+
+#: Set of idempotent HTTP methods
+IDEMPOTENT_METHODS = frozenset({'GET', 'HEAD', 'OPTIONS', 'TRACE'})
+
+#: Set of non-idempotent HTTP methods
+NON_IDEMPOTENT_METHODS = frozenset({'POST', 'PUT', 'PATCH', 'DELETE'})

--- a/aiohttp_middlewares/shield.py
+++ b/aiohttp_middlewares/shield.py
@@ -1,0 +1,151 @@
+"""
+==========================
+aiohttp_middlewares.shield
+==========================
+
+Middleware to shield application handlers by method or URL.
+
+Usage
+=====
+
+::
+
+    from aiohttp import web
+    from aiohttp_middlewares import NON_IDEMPOTENT_METHODS, shield_middleware
+
+    # Basic usage (shield by handler method)
+    app = web.Application(
+        middlewares=[shield_middleware(methods=IDEMPOTENT_METHODS)])
+
+    # Shield by handler URL
+    app = web.Application(
+        middlewares=[shield_middleware(urls=['/', '/about-us'])])
+
+    # Shield by handler method, but ignore shielding list of URLs
+    app = web.Application(
+        middlewares=[
+            shield_middleware(
+                methods=NON_IDEMPOTENT_METHODS,
+                ignore={'/api/documents', '/api/comments'})])
+
+    # Combine shielding by method and URL
+    SHIELD_URLS = {
+        '/api/documents': ['POST', 'DELETE'],
+        re.compile('/api/documents/\d+'): ['DELETE', 'PUT', 'PATCH'],
+    }
+    app = web.Application(
+        middlewares=[shield_middleware(urls=SHIELD_URLS)])
+
+"""
+
+import asyncio
+import logging
+
+from aiohttp import web
+
+from .types import Handler, Middleware, StrCollection, Urls
+from .utils import match_request
+
+
+logger = logging.getLogger(__name__)
+
+
+def shield_middleware(*,
+                      methods: StrCollection=None,
+                      urls: Urls=None,
+                      ignore: Urls=None) -> Middleware:
+    """Ensure that handler execution would not break on ``CancelledError``.
+
+    Shielding handlers allow to avoid breaking handler execution on
+    ``CancelledError`` (this happens for example while client closes
+    conneciton, but server still not ready to fullify response).
+
+    In most cases you need to shield non-idempotent methods (``POST``, ``PUT``,
+    ``PATCH``, ``DELETE``) and ignore shielding idempotent ``GET``, ``HEAD``,
+    ``OPTIONS`` and ``TRACE`` requests.
+
+    More about shielding coroutines in official Python docs,
+    https://docs.python.org/3/library/asyncio-task.html#asyncio.shield
+
+    Other possibility to allow shielding request handlers by URLs dict. In that
+    case  order of dict keys is necessary as they will be processed from first
+    to last added. In Python 3.6+ you can supply standard ``dict`` here, in
+    Python 3.5 please supply ``collections.OrderedDict`` instance instead.
+
+    To shield all non-idempotent methods you need to::
+
+        from aiohttp import web
+
+        app = web.Application(
+            middlewares=shield_middleware(methods=NON_IDEMPOTENT_METHODS))
+
+    To shield all non-idempotent methods and ``GET`` requests to
+    ``/downloads/*`` URLs::
+
+        import re
+
+        app = web.Application(
+            middlewares=shield_middleware(urls={
+                re.compile(r'^/downloads/.*$'): 'GET',
+                re.compile(r'.*'): NON_IDEMPOTENT_METHODS,
+            }))
+
+    :param methods:
+        Methods to shield. Use ``aiohttp_middlewares.IDEMPOTENT_METHODS`` to
+        shield requests to all idempotent methods (``POST``, ``PUT``,
+        ``PATCH``, ``DELETE``). Do not mix with ``urls``.
+    :param urls:
+        URLs to shield. Supports passing collection of strings or regexps or
+        dict where key is a string or regexp and value is a method or
+        collection of methods to shield. Do not mix with ``methods``.
+    :param ignore:
+        When ``methods`` specified ignore next collection of URL strings or
+        regexps from shielding. Do not mix with ``urls``.
+    """
+    if not methods and not urls:
+        raise ValueError('None of methods or urls argument passed.')
+    if methods and urls:
+        raise ValueError(
+            'Both methods and urls arguments passed, while only one expected.')
+    if urls and ignore:
+        raise ValueError('Unable to mix urls and ignore arguments.')
+
+    # Lower case methods to shield (if any)
+    methods_to_shield = {item.lower() for item in methods or []}
+
+    async def factory(app: web.Application, handler: Handler) -> Handler:
+        """Actual shield middleware factory."""
+        async def middleware(request: web.Request) -> web.Response:
+            """Shield handler execution if necessary."""
+            request_method = request.method.lower()
+            request_path = request.rel_url.path
+            log_extra = {'method': request.method, 'path': request_path}
+
+            # First attempt to process methods to shield
+            if methods_to_shield:
+                if request_method not in methods_to_shield:
+                    return await handler(request)
+
+                if (
+                    ignore and
+                    match_request(ignore, request_method, request_path)
+                ):
+                    logger.debug(
+                        'Ignore path from handler shielding.',
+                        extra=log_extra)
+                    return await handler(request)
+
+                logger.debug(
+                    'Activate shield middleware by matched method',
+                    extra=log_extra)
+                return await asyncio.shield(handler(request))
+
+            # Then attempt to shield handler by URLs collection / mapping
+            if urls and match_request(urls, request_method, request_path):
+                logger.debug(
+                    'Activate shield middleware by matched path',
+                    extra=log_extra)
+                return await asyncio.shield(handler(request))
+            return await handler(request)
+        return middleware
+    return factory

--- a/aiohttp_middlewares/types.py
+++ b/aiohttp_middlewares/types.py
@@ -7,13 +7,22 @@ Type annotation shortcuts for the project.
 
 """
 
-from typing import Awaitable, Callable, Dict, List, Set, Tuple, Union
+from typing import (
+    Awaitable,
+    Callable,
+    Dict,
+    FrozenSet,
+    List,
+    Set,
+    Tuple,
+    Union,
+)
 from typing.re import Pattern
 
 from aiohttp import web
 
 
-StrCollection = Union[List[str], Set[str], Tuple[str, ...]]
+StrCollection = Union[List[str], FrozenSet[str], Set[str], Tuple[str, ...]]
 StrDict = Dict[str, str]
 
 Url = Union[str, Pattern]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,11 +28,15 @@ API
 
 .. automodule:: aiohttp_middlewares
 
+.. automodule:: aiohttp_middlewares.timeout
+.. autofunction:: aiohttp_middlewares.timeout.timeout_middleware
+
+.. automodule:: aiohttp_middlewares.shield
+.. autofunction:: aiohttp_middlewares.shield.shield_middleware
+
 .. automodule:: aiohttp_middlewares.https
 .. autofunction:: aiohttp_middlewares.https.https_middleware
 
-.. automodule:: aiohttp_middlewares.timeout
-.. autofunction:: aiohttp_middlewares.timeout.timeout_middleware
 
 Changelog
 =========

--- a/tests/test_shield_middleware.py
+++ b/tests/test_shield_middleware.py
@@ -1,0 +1,75 @@
+import re
+
+import pytest
+
+from aiohttp import web
+
+from aiohttp_middlewares import NON_IDEMPOTENT_METHODS, shield_middleware
+
+
+def create_app(*, methods=None, urls=None, ignore=None):
+    app = web.Application(
+        middlewares=[
+            shield_middleware(methods=methods, urls=urls, ignore=ignore)])
+
+    app.router.add_get('/one', handler)
+    app.router.add_post('/one', handler)
+    app.router.add_get('/two', handler)
+    app.router.add_post('/two', handler)
+    app.router.add_patch('/three', handler)
+
+    return app
+
+
+async def handler(request):
+    return web.json_response(True)
+
+
+def test_shield_middleware_no_arguments():
+    with pytest.raises(ValueError):
+        shield_middleware()
+
+
+def test_shield_middleware_mixed_methods_and_urls():
+    with pytest.raises(ValueError):
+        shield_middleware(methods=NON_IDEMPOTENT_METHODS, urls=['/one'])
+
+
+def test_shield_middleware_mixed_urls_and_ignore():
+    with pytest.raises(ValueError):
+        shield_middleware(urls=['/one'], ignore=['/two'])
+
+
+@pytest.mark.parametrize('method, url', [
+    ('GET', '/one'),
+    ('GET', '/two'),
+    ('POST', '/one'),
+    ('POST', '/two'),
+    ('PATCH', '/three'),
+])
+async def test_shield_request_by_method(test_client, url, method):
+    app = create_app(methods=NON_IDEMPOTENT_METHODS, ignore=['/three'])
+    client = await test_client(app)
+
+    response = await client.request(method, url)
+    assert response.status == 200
+    assert await response.json() is True
+
+
+@pytest.mark.parametrize('method, url', [
+    ('GET', '/one'),
+    ('GET', '/two'),
+    ('POST', '/one'),
+    ('POST', '/two'),
+    ('PATCH', '/three'),
+])
+async def test_shield_request_by_url(test_client, url, method):
+    app = create_app(urls={
+        '/one': ['POST'],
+        re.compile(r'/(two|three)'): {'post', 'patch'},
+    })
+    client = await test_client(app)
+
+    response = await client.request(method, url)
+    assert response.status == 200
+    assert await response.json() is True


### PR DESCRIPTION
Middleware allow to shield request handlers to avoid breaking execution
in case of ``CancelledError`` (when client closes connection, but server
is not ready to prepare full response).