### PR TITLE
Speed up timeout middleware for strings

### DIFF
--- a/aiohttp_middlewares/utils.py
+++ b/aiohttp_middlewares/utils.py
@@ -16,10 +16,13 @@ def match_path(item: Url, path: str) -> bool:
     :param item: URL to compare with request path.
     :param path: Request path string.
     """
+    if isinstance(item, str):
+        return item == path
+
     try:
         return bool(item.match(path))  # type: ignore
     except (AttributeError, TypeError):
-        return item == path
+        return False
 
 
 def match_request(urls: Urls, method: str, path: str) -> bool:


### PR DESCRIPTION
Speed up timeout middleware for case when ignore urls are strings.

Before:
```
In [11]: timeit('match_request_old(urls, "GET", path)', globals=globals())
Out[11]: 6.540444647951517
```

After:
```
In [13]: timeit('match_request_new(urls, "GET", path)', globals=globals())
Out[13]: 2.176590914023109
```

For case with regular expressions we have slight slowdown:

Before:
```
In [18]: timeit('match_request_old(urls_re, "GET", path)', globals=globals())
Out[18]: 4.759645396959968
```

After:
```
In [16]: timeit('match_request_new(urls_re, "GET", path)', globals=globals())
Out[16]: 5.746110259031411
```