### PR TITLE
feature(error): Refactor handling exceptions in error middleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.1.0 (In Development)
+======================
+
+- Provide ``get_error_response`` coroutine to allow other projects to reuse
+  error handling logic
+
 1.0.0 (2020-01-14)
 ==================
 

--- a/aiohttp_middlewares/__init__.py
+++ b/aiohttp_middlewares/__init__.py
@@ -7,11 +7,16 @@ Collection of useful middlewares for aiohttp applications.
 
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0a0"
 
 from .constants import IDEMPOTENT_METHODS, NON_IDEMPOTENT_METHODS
 from .cors import cors_middleware
-from .error import default_error_handler, error_context, error_middleware
+from .error import (
+    default_error_handler,
+    error_context,
+    error_middleware,
+    get_error_response,
+)
 from .https import https_middleware
 from .shield import shield_middleware
 from .timeout import timeout_middleware
@@ -23,6 +28,7 @@ from .utils import match_path
     default_error_handler,
     error_context,
     error_middleware,
+    get_error_response,
     https_middleware,
     IDEMPOTENT_METHODS,
     match_path,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,11 @@ error_context
 
 .. autofunction:: aiohttp_middlewares.error.error_context
 
+get_error_response
+------------------
+
+.. autofunction:: aiohttp_middlewares.error.get_error_response
+
 match_path
 ----------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,30 +9,30 @@ alabaster==0.7.12         # via sphinx
 async-timeout==3.0.1      # via -r docs/requirements.in, aiohttp
 attrs==19.3.0             # via aiohttp
 babel==2.8.0              # via sphinx
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via aiohttp, requests
 docutils==0.16            # via sphinx
 idna==2.9                 # via requests, yarl
 imagesize==1.2.0          # via sphinx
-jinja2==2.11.1            # via sphinx
+jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 multidict==4.7.5          # via aiohttp, yarl
 packaging==20.3           # via sphinx
 pygments==2.6.1           # via sphinx
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pytz==2019.3              # via babel
 requests==2.23.0          # via sphinx
 six==1.14.0               # via packaging
 snowballstemmer==2.0.0    # via sphinx
 sphinx-autodoc-typehints==1.10.3  # via -r docs/requirements.in
-sphinx==2.4.4             # via -r docs/requirements.in, sphinx-autodoc-typehints
+sphinx==3.0.2             # via -r docs/requirements.in, sphinx-autodoc-typehints
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-urllib3==1.25.8           # via requests
+urllib3==1.25.9           # via requests
 yarl==1.4.2               # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ show_missing = true
 
 [tool.poetry]
 name = "aiohttp-middlewares"
-version = "1.0.0"
+version = "1.1.0a0"
 description = "Collection of useful middlewares for aiohttp applications."
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
Previously the logic behing error handling has been not reusable, but sometimes
it is need to post process response and still handle any errors there using
same logic.

To achieve that provide `aiohttp.error.get_error_response` coroutine, which
do all actual error handling.