### PR TITLE
chore(release): 1.1.0 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog
 =========
 
-1.1.0 (In Development)
-======================
+1.1.0 (2020-04-21)
+==================
 
 - Provide ``get_error_response`` coroutine to allow other projects to reuse
   error handling logic

--- a/aiohttp_middlewares/__init__.py
+++ b/aiohttp_middlewares/__init__.py
@@ -7,7 +7,7 @@ Collection of useful middlewares for aiohttp applications.
 
 """
 
-__version__ = "1.1.0a0"
+__version__ = "1.1.0"
 
 from .constants import IDEMPOTENT_METHODS, NON_IDEMPOTENT_METHODS
 from .cors import cors_middleware

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ show_missing = true
 
 [tool.poetry]
 name = "aiohttp-middlewares"
-version = "1.1.0a0"
+version = "1.1.0"
 description = "Collection of useful middlewares for aiohttp applications."
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
- Provide `get_error_response` coroutine to allow reuse error handling logic in custom middlewares. Usable, when post processing responses (error responses as well) is required and may result in extra errors