### PR TITLE
docs: Update Read the Docs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,14 @@
 version: 2
 
-sphinx:
-  configuration: "docs/conf.py"
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.10"
 
 python:
-  version: "3.10"
   install:
-    - requirements: "docs/requirements.txt"
-    - requirements: "docs/requirements-sphinx.txt"
+    - requirements: "./docs/requirements.txt"
+    - requirements: "./docs/requirements-sphinx.txt"
+
+sphinx:
+  configuration: "./docs/conf.py"


### PR DESCRIPTION
To set python version via `build.tools.python` instead of `python.version`.