### PR TITLE
refactor!: Bump aiohttp & async-timeout deps lower bounds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ aiohttp-middlewares
 Collection of useful middlewares for `aiohttp.web`_ applications.
 
 - Works on `Python`_ 3.7+
-- Works with `aiohttp.web`_ 3.7+
+- Works with `aiohttp.web`_ 3.8.1+
 - BSD licensed
 - Latest documentation `on Read The Docs
   <https://aiohttp-middlewares.readthedocs.io/>`_

--- a/poetry.lock
+++ b/poetry.lock
@@ -409,7 +409,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "63ddc7935e679cf307716f5eb7e79b842593887319b4e8313e31cc6b27a308c4"
+content-hash = "e9eecaa73c12f6796df7a85a4ebe08e4df028b41ed50420c5dce12aca1b5ed14"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-aiohttp = "^3.7.0"
-async-timeout = ">=3.0,<5.0"
+aiohttp = "^3.8.1"
+async-timeout = "^4.0.2"
 yarl = "^1.5.1"
 
 [tool.poetry.dev-dependencies]
@@ -95,13 +95,15 @@ coveralls = "^3.3.1"
 mypy = "^0.961"
 pytest = "^7.1.2"
 pytest-aiohttp = "^1.0.4"
+pytest-asyncio = "^0.18.3"
 pytest-cov = "^3.0.0"
 
 [tool.pytest.ini_options]
-minversion = "6.2.5"
+minversion = "7.1.2"
 addopts = "--cov --no-cov-on-fail"
 testpaths = ["./tests/"]
 log_level = "info"
+asyncio_mode = "auto"
 
 [tool.tox]
 legacy_tox_ini = """
@@ -133,7 +135,7 @@ commands =
 [testenv:py310-minimum-requirements]
 commands_pre =
   poetry install
-  poetry run python3 -m pip install aiohttp==3.7.0 async-timeout==3.0.0 yarl==1.5.1
+  poetry run python3 -m pip install aiohttp==3.8.1 async-timeout==4.0.2 yarl==1.5.1
 """
 
 [build-system]

--- a/src/aiohttp_middlewares/timeout.py
+++ b/src/aiohttp_middlewares/timeout.py
@@ -138,7 +138,7 @@ def timeout_middleware(
             )
             return await handler(request)
 
-        with timeout(seconds):
+        async with timeout(seconds):
             return await handler(request)
 
     return middleware

--- a/tests/test_shield_middleware.py
+++ b/tests/test_shield_middleware.py
@@ -87,7 +87,7 @@ async def test_shield_request_by_url(aiohttp_client, url, method):
     "method, value",
     [("DELETE", False), ("GET", False), ("POST", True), ("PUT", False)],
 )
-async def test_shield_middleware_funcitonal(loop, method, value):
+async def test_shield_middleware_funcitonal(event_loop, method, value):
     flag = False
     client_ready = asyncio.Event()
     handler_ready = asyncio.Event()
@@ -106,7 +106,7 @@ async def test_shield_middleware_funcitonal(loop, method, value):
 
     # Run handler in a task.
     middleware = shield_middleware(methods=frozenset({"POST"}))
-    task = loop.create_task(
+    task = event_loop.create_task(
         middleware(make_mocked_request(method, "/"), handler)
     )
     await handler_ready.wait()


### PR DESCRIPTION
As well as ensure that timeout context manager is an async one, not sync.

On top of that fix warnings for `event_loop` fixture in tests and `async_mode`.

Fixes: #81 