### PR TITLE
test: Add tests to latest changes in CORS middleware

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,2 +1,3 @@
 - `Igor Davydenko <https://github.com/playpauseandstop>`_
 - `Alex Kuzmenko <https://github.com/alxpy>`_
+- `Kaarle Ritvanen <https://github.com/kunkku>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version_files = ["./pyproject.toml", "./src/aiohttp_middlewares/__init__.py"]
 
 [tool.black]
 line_length = 79
+target_version = ["py37"]
 
 [tool.coverage.run]
 branch = true

--- a/src/aiohttp_middlewares/cors.py
+++ b/src/aiohttp_middlewares/cors.py
@@ -23,6 +23,20 @@ visit:
 - `Wikipedia <https://en.m.wikipedia.org/wiki/Cross-origin_resource_sharing>`_
 - Or `MDN <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`_
 
+.. versionchanged:: 2.1.0
+
+If CORS request ends up with :class:`aiohttp.web.HTTPException` - the exception
+will be used as a handler ``response`` and CORS headers will still be added to
+it, which means that even ``aiohttp`` cannot properly handle request to some
+URL, the response will still contain all necessary CORS headers.
+
+.. note::
+
+   Thanks `Kaarle Ritvanen <https://github.com/kunkku>`_ for fix in
+   `aiohttp-middlewares#98
+   <https://github.com/playpauseandstop/aiohttp-middlewares/pull/98>`_ and
+   `Jonathan Heathcote <https://github.com/mossblaser>`_ for the review.
+
 Configuration
 =============
 
@@ -239,12 +253,13 @@ def cors_middleware(
         else:
             try:
                 response = await handler(request)
+            # In case of ``HTTPException`` - use it as handler response
             except web.HTTPException as exc:
                 response = web.Response(
                     headers=exc.headers,
                     status=exc.status,
                     reason=exc.reason,
-                    text=exc.text
+                    text=exc.text,
                 )
 
         # Now check origin heaer

--- a/src/aiohttp_middlewares/error.py
+++ b/src/aiohttp_middlewares/error.py
@@ -9,7 +9,7 @@ Middleware to handle errors in aiohttp applications.
 
 .. versionchanged:: 1.0.0
 
-Previosly, ``error_middleware`` required ``default_handler`` to be passed
+Previously, ``error_middleware`` required ``default_handler`` to be passed
 on initialization. However in **1.0.0** version ``aiohttp-middlewares`` ships
 default error handler, which log exception traceback into
 ``aiohttp_middlewares.error`` logger and responds with given JSON:
@@ -164,7 +164,7 @@ def error_middleware(
     *,
     default_handler: Handler = default_error_handler,
     config: Config = None,
-    ignore_exceptions: Union[ExceptionType, Tuple[ExceptionType, ...]] = None
+    ignore_exceptions: Union[ExceptionType, Tuple[ExceptionType, ...]] = None,
 ) -> Middleware:
     """Middleware to handle exceptions in aiohttp applications.
 
@@ -241,7 +241,7 @@ async def get_error_response(
     *,
     default_handler: Handler = default_error_handler,
     config: Config = None,
-    ignore_exceptions: Union[ExceptionType, Tuple[ExceptionType, ...]] = None
+    ignore_exceptions: Union[ExceptionType, Tuple[ExceptionType, ...]] = None,
 ) -> web.StreamResponse:
     """Actual coroutine to get response for given request & error.
 


### PR DESCRIPTION
To ensure that CORS headers will be added to responses derived from catched `web.HTTPException`'s.

Related: #98