### PR TITLE
docs: Fix read the docs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,8 +8,8 @@ build:
     post_create_environment:
       # Install poetry
       - "curl -sSL https://install.python-poetry.org | python3 -"
-      # Install project's dependencies
-      - "${HOME}/.poetry/bin/poetry install --only main,docs"
+      # Install project and docs dependencies
+      - "${HOME}/.local/bin/poetry install --only main,docs"
 
 sphinx:
   configuration: "./docs/conf.py"


### PR DESCRIPTION
To use poetry from `${HOME}/.local/bin/poetry`, not from `${HOME}/.poetry/bin/poetry`.