### PR TITLE
style: Enforce mypy no-implicit-optional setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,13 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.badabump]
 version_type = "semver"
-version_files = ["./pyproject.toml", "./src/aiohttp_middlewares/__init__.py"]
+version_files = [
+  "./pyproject.toml",
+  "./src/aiohttp_middlewares/__init__.py",
+]
 
 [tool.black]
 line_length = 79
@@ -14,6 +21,8 @@ source = ["aiohttp_middlewares"]
 source = ["./src/"]
 
 [tool.coverage.report]
+exclude_lines = ["if TYPE_CHECKING:", "@overload"]
+omit = ["./src/*/__main__.py", "./src/*/annotations.py"]
 fail_under = 95
 skip_covered = true
 show_missing = true
@@ -40,6 +49,7 @@ follow_imports = "normal"
 follow_imports_for_stubs = true
 ignore_missing_imports = false
 namespace_packages = true
+no_implicit_optional = true
 mypy_path = "./src/"
 python_executable = "./.venv/bin/python3"
 show_column_numbers = true
@@ -149,7 +159,3 @@ commands_pre =
   poetry install --only main,test
   poetry run python3 -m pip install aiohttp==3.8.1 async-timeout==4.0.2 yarl==1.5.1
 """
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"

--- a/src/aiohttp_middlewares/cors.py
+++ b/src/aiohttp_middlewares/cors.py
@@ -115,7 +115,7 @@ Usage
 
 import logging
 import re
-from typing import Pattern, Tuple
+from typing import Pattern, Tuple, Union
 
 from aiohttp import web
 
@@ -158,13 +158,13 @@ logger = logging.getLogger(__name__)
 def cors_middleware(
     *,
     allow_all: bool = False,
-    origins: UrlCollection = None,
-    urls: UrlCollection = None,
-    expose_headers: StrCollection = None,
+    origins: Union[UrlCollection, None] = None,
+    urls: Union[UrlCollection, None] = None,
+    expose_headers: Union[StrCollection, None] = None,
     allow_headers: StrCollection = DEFAULT_ALLOW_HEADERS,
     allow_methods: StrCollection = DEFAULT_ALLOW_METHODS,
     allow_credentials: bool = False,
-    max_age: int = None,
+    max_age: Union[int, None] = None,
 ) -> Middleware:
     """Middleware to provide CORS headers for aiohttp applications.
 

--- a/src/aiohttp_middlewares/error.py
+++ b/src/aiohttp_middlewares/error.py
@@ -163,8 +163,10 @@ def error_context(request: web.Request) -> Iterator[ErrorContext]:
 def error_middleware(
     *,
     default_handler: Handler = default_error_handler,
-    config: Config = None,
-    ignore_exceptions: Union[ExceptionType, Tuple[ExceptionType, ...]] = None,
+    config: Union[Config, None] = None,
+    ignore_exceptions: Union[
+        ExceptionType, Tuple[ExceptionType, ...], None
+    ] = None,
 ) -> Middleware:
     """Middleware to handle exceptions in aiohttp applications.
 
@@ -240,8 +242,10 @@ async def get_error_response(
     err: Exception,
     *,
     default_handler: Handler = default_error_handler,
-    config: Config = None,
-    ignore_exceptions: Union[ExceptionType, Tuple[ExceptionType, ...]] = None,
+    config: Union[Config, None] = None,
+    ignore_exceptions: Union[
+        ExceptionType, Tuple[ExceptionType, ...], None
+    ] = None,
 ) -> web.StreamResponse:
     """Actual coroutine to get response for given request & error.
 

--- a/src/aiohttp_middlewares/https.py
+++ b/src/aiohttp_middlewares/https.py
@@ -25,6 +25,7 @@ Usage
 """
 
 import logging
+from typing import Union
 
 from aiohttp import web
 
@@ -36,7 +37,9 @@ DEFAULT_MATCH_HEADERS = {"X-Forwarded-Proto": "https"}
 logger = logging.getLogger(__name__)
 
 
-def https_middleware(match_headers: DictStrStr = None) -> Middleware:
+def https_middleware(
+    match_headers: Union[DictStrStr, None] = None
+) -> Middleware:
     """
     Change scheme for current request when aiohttp application deployed behind
     reverse proxy with HTTPS enabled.

--- a/src/aiohttp_middlewares/shield.py
+++ b/src/aiohttp_middlewares/shield.py
@@ -53,6 +53,7 @@ Usage
 
 import asyncio
 import logging
+from typing import Union
 
 from aiohttp import web
 
@@ -69,7 +70,10 @@ logger = logging.getLogger(__name__)
 
 
 def shield_middleware(
-    *, methods: StrCollection = None, urls: Urls = None, ignore: Urls = None
+    *,
+    methods: Union[StrCollection, None] = None,
+    urls: Union[Urls, None] = None,
+    ignore: Union[Urls, None] = None,
 ) -> Middleware:
     """
     Ensure that handler execution would not break on

--- a/src/aiohttp_middlewares/timeout.py
+++ b/src/aiohttp_middlewares/timeout.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 
 
 def timeout_middleware(
-    seconds: Union[int, float], *, ignore: Urls = None
+    seconds: Union[int, float], *, ignore: Union[Urls, None] = None
 ) -> Middleware:
     """Ensure that request handling does not exceed X seconds.
 


### PR DESCRIPTION
Which has been introduced in `mypy==0.981` and enforce proper type annotations for args / kwargs with default `None` value.