### PR TITLE
docs: Fix another typo in docstring

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,3 +1,4 @@
 - `Igor Davydenko <https://github.com/playpauseandstop>`_
 - `Alex Kuzmenko <https://github.com/alxpy>`_
 - `Kaarle Ritvanen <https://github.com/kunkku>`_
+- `Yoan Blanc <https://github.com/greut>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,8 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     "https://docs.python.org/3/": None,
-    "https://aiohttp.readthedocs.io/en/stable/": None,
+    "https://docs.aiohttp.org/en/stable/": None,
+    "https://yarl.aio-libs.org/en/stable/": None,
 }
 
 ogp_site_url = "https://aiohttp-middlewares.readthedocs.io"

--- a/src/aiohttp_middlewares/cors.py
+++ b/src/aiohttp_middlewares/cors.py
@@ -176,7 +176,7 @@ def cors_middleware(
         Allow content access for given list of origins. Support supplying
         strings for exact origin match or regex instances. By default: ``None``
     :param urls:
-        Allow contect access for given list of URLs in aiohttp application.
+        Allow content access for given list of URLs in aiohttp application.
         By default: *apply CORS headers for all URLs*
     :param expose_headers:
         List of headers to be exposed with every CORS request. By default:


### PR DESCRIPTION
As well as update intersphinx mapping for `aiohttp` and add mapping for `yarl` library.

Also add @greut to `AUTHORS.txt`.
