### PR TITLE
Fix importing Middleware type alias

### DIFF
--- a/src/aiohttp_middlewares/annotations.py
+++ b/src/aiohttp_middlewares/annotations.py
@@ -7,6 +7,8 @@ Type annotation shortcuts for ``aiohttp_middlewares`` library.
 
 """
 
+import importlib
+
 from typing import (
     Any,
     Awaitable,
@@ -19,8 +21,14 @@ from typing import (
 )
 
 from aiohttp import web
-from aiohttp.web_middlewares import _Middleware as Middleware
 from yarl import URL
+
+try:
+   # (<3.9.0) Try to import Middleware from aiohttp.web_middlewares
+   Middleware = importlib.import_module('aiohttp.web_middlewares')._Middleware
+except AttributeError:
+   # (>=3.9.0) If that fails, import Middleware from aiohttp.typedefs
+   Middleware = importlib.import_module('aiohttp.typedefs').Middleware
 
 
 # Make flake8 happy


### PR DESCRIPTION
`_Middleware` was removed upstream in [#5898][0]. We can now use `Middleware` type alias from the typedefs starting from aiohttp 3.9.0

This leads to following error:

```
ImportError: cannot import name '_Middleware' from 'aiohttp.web_middlewares'
```

This change should be backwards compatible with older version of aiohttp.

[0]: https://github.com/aio-libs/aiohttp/pull/5898