### PR TITLE
build: Configure Trusted Publisher for the repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,6 @@ jobs:
     needs: ["test"]
 
     uses: "./.github/workflows/ci_package.yml"
-    secrets:
-      pypi-user: "${{ secrets.PYPI_USERNAME }}"
-      pypi-password: "${{ secrets.PYPI_PASSWORD }}"
 
   release:
     needs: ["package"]

--- a/.github/workflows/ci_package.yml
+++ b/.github/workflows/ci_package.yml
@@ -9,15 +9,6 @@ on:
         required: false
         default: "4.0.2"
 
-    secrets:
-      pypi-user:
-        description: "PyPI username to use."
-        required: true
-
-      pypi-password:
-        description: "PyPI password (token) to use."
-        required: true
-
 jobs:
   package:
     name: "Build & Deploy Package"
@@ -44,6 +35,3 @@ jobs:
       - name: "Publish package"
         if: "${{ startsWith(github.ref, 'refs/tags/') }}"
         uses: "pypa/gh-action-pypi-publish@v1.8.11"
-        with:
-          user: "${{ secrets.pypi-user }}"
-          password: "${{ secrets.pypi-password }}"


### PR DESCRIPTION
Fixes: #196
Related: https://til.simonwillison.net/pypi/pypi-releases-from-github
