### PR TITLE
ci: Grant permissions to Package reusable wofklow in CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
   package:
     needs: ["test"]
 
+    permissions:
+      id-token: "write"
+
     uses: "./.github/workflows/ci_package.yml"
 
   release:


### PR DESCRIPTION
Issue: #196
