### PR TITLE
Remove misleading debug message "Provide CORS headers for request"

### DIFF
--- a/src/aiohttp_middlewares/cors.py
+++ b/src/aiohttp_middlewares/cors.py
@@ -320,7 +320,6 @@ def cors_middleware(
             raise web.HTTPOk(text="", headers=response.headers)
 
         # Otherwise return normal response
-        logger.debug("Provide CORS headers for request", extra=log_extra)
         return response
 
     return middleware


### PR DESCRIPTION
The line logger.debug("Provide CORS headers for request", extra=log_extra) misleads users as if the request was missing CORS headers, when the code flow was a normal response.